### PR TITLE
Add lucide pack

### DIFF
--- a/plugins/icon-finder/src/components/Previews.tsx
+++ b/plugins/icon-finder/src/components/Previews.tsx
@@ -468,3 +468,97 @@ export function BoxPreview() {
     </>
   );
 }
+
+export function LucidePreview() {
+  return (
+    <>
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="24"
+        height="24"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      >
+        <path d="M19 21v-2a4 4 0 0 0-4-4H9a4 4 0 0 0-4 4v2" />
+        <circle cx="12" cy="7" r="4" />
+      </svg>
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="24"
+        height="24"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      >
+        <circle cx="8" cy="21" r="1" />
+        <circle cx="19" cy="21" r="1" />
+        <path d="M2.05 2.05h2l2.66 12.42a2 2 0 0 0 2 1.58h9.78a2 2 0 0 0 1.95-1.57l1.65-7.43H5.12" />
+      </svg>
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="24"
+        height="24"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      >
+        <path d="M6 2 3 6v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V6l-3-4Z" />
+        <path d="M3 6h18" />
+        <path d="M16 10a4 4 0 0 1-8 0" />
+      </svg>
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="24"
+        height="24"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      >
+        <path d="M17.5 19H9a7 7 0 1 1 6.71-9h1.79a4.5 4.5 0 1 1 0 9Z" />
+      </svg>
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="24"
+        height="24"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      >
+        <circle cx="12" cy="12" r="10" />
+        <polyline points="12 6 12 12 16 14" />
+      </svg>
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="24"
+        height="24"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      >
+        <circle cx="12" cy="12" r="10" />
+        <path d="M6 12c0-1.7.7-3.2 1.8-4.2" />
+        <circle cx="12" cy="12" r="2" />
+        <path d="M18 12c0 1.7-.7 3.2-1.8 4.2" />
+      </svg>
+    </>
+  );
+}

--- a/plugins/icon-finder/src/config.tsx
+++ b/plugins/icon-finder/src/config.tsx
@@ -4,6 +4,7 @@ import {
   BoxPreview,
   FeatherPreview,
   HeroPreview,
+  LucidePreview,
   PhosphorPreview,
   RemixPreview,
 } from "./components/Previews.tsx";
@@ -98,5 +99,14 @@ export const packs = [
     },
     site: "https://github.com/atisawd/boxicons/",
     preview: BoxPreview,
+  },
+  {
+    name: "Lucide icons",
+    loader: () =>
+      // @ts-expect-error
+      import("react-icons/lu") as Promise<Record<string, IconComponent>>,
+    license: { name: "ISC", url: "https://lucide.dev/license" },
+    site: "https://lucide.dev/",
+    preview: LucidePreview,
   },
 ] satisfies IconPack[];


### PR DESCRIPTION
Hi, i wanted to use lucide icons and wondered why not do it myself ?

I didn't include the fill version cause it is not officialy supported [here](https://lucide.dev/guide/advanced/filled-icons).

If this is good i plan on adding the icon sets mentionned in this [issue](https://github.com/Grafikart/penpot-plugins/issues/2)

I'm happy for any feedback on this.